### PR TITLE
Fix homepage and add repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
   "bin": {
     "agreed-ui": "./bin/agreed-ui.js"
   },
-  "homepage": "./",
+  "homepage": "https://github.com/recruit-tech/agreed-ui",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/recruit-tech/agreed-ui.git"
+  },
   "dependencies": {
     "agreed-core": "^3.0.0",
     "axios": "^0.18.0",


### PR DESCRIPTION
- Fixed homepage field of package.json (this should be an url).
- Added repository field

This change suppresses the one of the warnings npm cli shows.

```
$ npm i
npm WARN agreed-ui@0.1.2 No repository field.
npm WARN agreed-ui@0.1.2 No license field.
```