### PR TITLE
Use lodash.template for templating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4645,14 +4645,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4661,6 +4653,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6597,8 +6597,7 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -6640,7 +6639,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "3.0.0",
         "lodash.templatesettings": "4.1.0"
@@ -6650,7 +6648,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "3.0.0"
       }
@@ -10404,15 +10401,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -10457,6 +10445,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server/index.js",
     "start:dev": "npm run start:dev:server & npm run start -- --port 3001",
     "start:dev:server": "react-scripts start",
-    "build:static": "react-scripts build",
+    "build:static": "PUBLIC_URL=./ react-scripts build",
     "build": "node scripts/build.js"
   },
   "bin": {
@@ -24,6 +24,7 @@
     "express": "^4.16.2",
     "fs-extra": "^5.0.0",
     "json-schema-to-flow-type": "^0.2.6",
+    "lodash.template": "^4.4.0",
     "minimist": "^1.2.0",
     "npm-run-all": "^4.1.2",
     "serialize-javascript": "^1.4.0"

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
     </noscript>
     <div id="root"></div>
     <script>
-      window.AGREES = "__AGREES__";
+      window.AGREES = "<\%= __AGREES__ \%>";
     </script>
     <!--
       This HTML file is a template.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,7 @@ const fse = require('fs-extra')
 const path = require('path')
 const minimist = require('minimist')
 const serialize = require('serialize-javascript')
+const template = require('lodash.template')
 
 const argv = minimist(process.argv.slice(2))
 const getAgreements = require('../server/lib/getAgreements')
@@ -18,4 +19,4 @@ const html = fs.readFileSync(srcPath, 'utf8')
 
 fse.copySync(path.dirname(srcPath), path.dirname(destPath))
 
-fs.writeFileSync(destPath, html.replace(`"${'__AGREES__'}"`, serialized))
+fs.writeFileSync(destPath, template(html, { interpolate: /"<%=([\s\S]+?)%>"/g })({ __AGREES__: serialized }))

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -27,7 +27,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    if (window.AGREES !== '__AGREES__') {
+    if (Array.isArray(window.AGREES)) {
       return this.setState({ agrees: window.AGREES })
     }
 


### PR DESCRIPTION
This PR introduces `lodash.template` and use it for replacing `__AGREES__` in html file. This is safer than `string.replace` and fixes the issue like #5.

---
fix #5