### PR TITLE
Fix trailing comma for node 6

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ app.get('/', (req, res) => {
     template(html, { interpolate: /"<%=([\s\S]+?)%>"/g })({
       agrees: serialized,
       title: argv.title,
-    }),
+    })
   )
 })
 


### PR DESCRIPTION
- 関数コール末尾のカンマが node 6 だと文法的にエラーになるようだったので、修正してみました